### PR TITLE
Handle functions not yet loaded, gracefully

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -681,9 +681,12 @@ For example, \"(some-func FOO &optional BAR)\"."
   (let (docstring-sig
         source-sig)
     ;; Get the usage from the function definition.
-    (let ((formatted-args
-           (-map #'helpful--format-argument
-                 (help-function-arglist sym))))
+    (let* ((function-args (help-function-arglist sym))
+           (formatted-args
+            (if (listp function-args)
+                (-map #'helpful--format-argument
+                      function-args)
+              (list function-args))))
       (setq source-sig
             (if formatted-args
                 (format "(%s %s)" sym

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -9,6 +9,8 @@
   "Docstring here too."
   nil)
 
+(autoload 'some-unused-function "somelib.el")
+
 (defadvice test-foo-advised (before test-advice1 activate)
   "Placeholder advice 1."
   nil)
@@ -112,3 +114,9 @@ variables defined without `defvar'."
 (ert-deftest helpful-variable ()
   "Smoke test for `helpful-variable'."
   (helpful-variable 'tab-width))
+
+(ert-deftest helpfpul--signature ()
+    "Ensure that autoloaded functions are handled gracefully"
+  (should
+   (equal (helpful--signature 'some-unused-function)
+          "(some-unused-function [Arg list not available until function definition is loaded.])")))


### PR DESCRIPTION
For functions that are not yet loaded (for example 'erc), the current code crashes because 
```elisp
(-map #'helpful--format-argument
                 (help-function-arglist sym))
```
tries to call `#'helpful--format-argument` on chars.