### PR TITLE
Require shut-up

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -46,6 +46,7 @@
 (require 'help)
 (require 'dash)
 (require 's)
+(require 'shut-up)
 (require 'find-func)
 (require 'nadvice)
 (require 'info-look)


### PR DESCRIPTION
Otherwise helpful fails if shut-up is not loaded yet.

I don't use `package.el` and calling helpful breaks without requireing shut-up first.