### PR TITLE
Refactor helpful-update formatting

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -84,7 +84,7 @@ show the value of buffer-local variables.")
 
 (defun helpful--heading (text)
   "Propertize TEXT as a heading."
-  (propertize text 'face 'bold))
+  (format "%s\n" (propertize text 'face 'bold)))
 
 (defun helpful--format-closure (sym form)
   "Given a closure, return an equivalent defun form."
@@ -916,23 +916,23 @@ state of the current symbol."
 
     (if helpful--callable-p
         (insert
-         (helpful--heading (format "%s Signature\n"
+         (helpful--heading (format "%s Signature"
                                    (if (macrop helpful--sym) "Macro" "Function")))
          (helpful--syntax-highlight (helpful--signature helpful--sym)))
       (insert
-       (helpful--heading "Variable\n")
+       (helpful--heading "Variable")
        (symbol-name helpful--sym)))
 
     (-when-let (docstring (helpful--docstring helpful--sym helpful--callable-p))
       (helpful--insert-section-break)
       (insert
-       (helpful--heading (format "%s Documentation\n" (cond
-                                                       ((not helpful--callable-p)
-                                                        "Variable")
-                                                       ((macrop helpful--sym)
-                                                        "Macro")
-                                                       (t
-                                                        "Function"))))
+       (helpful--heading (format "%s Documentation" (cond
+                                                     ((not helpful--callable-p)
+                                                      "Variable")
+                                                     ((macrop helpful--sym)
+                                                      "Macro")
+                                                     (t
+                                                      "Function"))))
        (helpful--format-docstring docstring))
       (when (helpful--in-manual-p helpful--sym)
         (insert
@@ -947,7 +947,7 @@ state of the current symbol."
       (let ((sym helpful--sym)
             (buf (or helpful--associated-buffer (current-buffer))))
         (insert
-         (helpful--heading "Value\n")
+         (helpful--heading "Value")
          (helpful--pretty-print
           (helpful--sym-value sym buf))
          "\n\n")
@@ -978,12 +978,12 @@ state of the current symbol."
     (when (commandp helpful--sym)
       (helpful--insert-section-break)
       (insert
-       (helpful--heading "Key Bindings\n")
+       (helpful--heading "Key Bindings")
        (helpful--format-keys helpful--sym)))
 
     (helpful--insert-section-break)
     (insert
-     (helpful--heading "References\n")
+     (helpful--heading "References")
      (cond
       ((and source-path references)
        (format "References in %s:\n%s"
@@ -1007,7 +1007,7 @@ state of the current symbol."
     (when (helpful--advised-p helpful--sym)
       (helpful--insert-section-break)
       (insert
-       (helpful--heading "Advice\n")
+       (helpful--heading "Advice")
        (format
         "This %s is advised." (if (macrop helpful--sym) "macro" "function"))))
 
@@ -1026,7 +1026,7 @@ state of the current symbol."
                 (not primitive-p))))
       (when (or can-edebug can-trace can-disassemble can-forget)
         (helpful--insert-section-break)
-        (insert (helpful--heading "Debugging\n")))
+        (insert (helpful--heading "Debugging")))
       (when can-edebug
         (insert
          (helpful--button
@@ -1072,14 +1072,14 @@ state of the current symbol."
       (when (> (length aliases) 1)
         (helpful--insert-section-break)
         (insert
-         (helpful--heading "Aliases\n")
+         (helpful--heading "Aliases")
          (s-join "\n" (--map (helpful--format-alias it helpful--callable-p)
                              aliases)))))
 
     (helpful--insert-section-break)
 
     (insert
-     (helpful--heading "Source Code\n")
+     (helpful--heading "Source Code")
      (cond
       (source-path
        (concat
@@ -1119,7 +1119,7 @@ state of the current symbol."
 
     (-when-let (formatted-props (helpful--format-properties helpful--sym))
       (insert
-       (helpful--heading "Symbol Properties\n")
+       (helpful--heading "Symbol Properties")
        formatted-props))
 
     (goto-char (point-min))

--- a/helpful.el
+++ b/helpful.el
@@ -296,7 +296,7 @@ or disable if already enabled."
           ;; exist. Otherwise, we can clean it up.
           (when (and created (not should-edebug))
             (kill-buffer buf)))
-      
+
       (user-error "Could not find source for edebug"))))
 
 (defun helpful--edebug (button)
@@ -878,6 +878,10 @@ POSITION-HEADS takes the form ((123 (defun foo)) (456 (defun bar)))."
   (with-current-buffer buf
     (symbol-value sym)))
 
+(defun helpful--insert-section-break ()
+  "Insert section break into helpful buffer."
+  (insert "\n\n"))
+
 (defun helpful-update ()
   "Update the current *Helpful* buffer to the latest
 state of the current symbol."
@@ -907,7 +911,9 @@ state of the current symbol."
         (setq references
               (--map (helpful--outer-sexp buf it) positions))
         (kill-buffer buf)))
+
     (erase-buffer)
+
     (if helpful--callable-p
         (insert
          (helpful--heading
@@ -921,8 +927,8 @@ state of the current symbol."
        (symbol-name helpful--sym)))
 
     (-when-let (docstring (helpful--docstring helpful--sym helpful--callable-p))
+      (helpful--insert-section-break)
       (insert
-       "\n\n"
        (helpful--heading
         (cond
          ((not helpful--callable-p)
@@ -941,10 +947,11 @@ state of the current symbol."
           'symbol helpful--sym))))
 
     (when (not helpful--callable-p)
+      (helpful--insert-section-break)
       (let ((sym helpful--sym)
             (buf (or helpful--associated-buffer (current-buffer))))
         (insert
-         (helpful--heading "\n\nValue\n")
+         (helpful--heading "Value\n")
          (helpful--pretty-print
           (helpful--sym-value sym buf))
          "\n\n")
@@ -973,12 +980,14 @@ state of the current symbol."
     ;; Show keybindings.
     ;; TODO: allow users to conveniently add and remove keybindings.
     (when (commandp helpful--sym)
+      (helpful--insert-section-break)
       (insert
-       (helpful--heading "\n\nKey Bindings\n")
+       (helpful--heading "Key Bindings\n")
        (helpful--format-keys helpful--sym)))
 
+    (helpful--insert-section-break)
     (insert
-     (helpful--heading "\n\nReferences\n")
+     (helpful--heading "References\n")
      (cond
       ((and source-path references)
        (format "References in %s:\n%s"
@@ -1000,8 +1009,9 @@ state of the current symbol."
       'callable-p helpful--callable-p))
 
     (when (helpful--advised-p helpful--sym)
+      (helpful--insert-section-break)
       (insert
-       (helpful--heading "\n\nAdvice\n")
+       (helpful--heading "Advice\n")
        (format
         "This %s is advised." (if (macrop helpful--sym) "macro" "function"))))
 
@@ -1019,7 +1029,8 @@ state of the current symbol."
            (and (not (special-form-p helpful--sym))
                 (not primitive-p))))
       (when (or can-edebug can-trace can-disassemble can-forget)
-        (insert (helpful--heading "\n\nDebugging\n")))
+        (helpful--insert-section-break)
+        (insert (helpful--heading "Debugging\n")))
       (when can-edebug
         (insert
          (helpful--button
@@ -1063,13 +1074,16 @@ state of the current symbol."
 
     (let ((aliases (helpful--aliases helpful--sym helpful--callable-p)))
       (when (> (length aliases) 1)
+        (helpful--insert-section-break)
         (insert
-         (helpful--heading "\n\nAliases\n")
+         (helpful--heading "Aliases\n")
          (s-join "\n" (--map (helpful--format-alias it helpful--callable-p)
                              aliases)))))
 
+    (helpful--insert-section-break)
+
     (insert
-     (helpful--heading "\n\nSource Code\n")
+     (helpful--heading "Source Code\n")
      (cond
       (source-path
        (concat
@@ -1106,9 +1120,11 @@ state of the current symbol."
          (helpful--syntax-highlight
           (helpful--pretty-print source))))))
 
+    (helpful--insert-section-break)
+
     (-when-let (formatted-props (helpful--format-properties helpful--sym))
       (insert
-       (helpful--heading "\n\nSymbol Properties\n")
+       (helpful--heading "Symbol Properties\n")
        formatted-props))
 
     (goto-char (point-min))

--- a/helpful.el
+++ b/helpful.el
@@ -894,6 +894,13 @@ state of the current symbol."
          (start-column (current-column))
          (primitive-p (helpful--primitive-p
                        helpful--sym helpful--callable-p))
+         (sym-type (cond
+                    ((not helpful--callable-p)
+                     "Variable")
+                    ((macrop helpful--sym)
+                     "Macro")
+                    (t
+                     "Function")))
          (look-for-src (or (not primitive-p)
                            find-function-C-source-directory))
          (source (when look-for-src
@@ -916,23 +923,16 @@ state of the current symbol."
 
     (if helpful--callable-p
         (insert
-         (helpful--heading (format "%s Signature"
-                                   (if (macrop helpful--sym) "Macro" "Function")))
+         (helpful--heading (format "%s Signature" sym-type))
          (helpful--syntax-highlight (helpful--signature helpful--sym)))
       (insert
-       (helpful--heading "Variable")
+       (helpful--heading sym-type)
        (symbol-name helpful--sym)))
 
     (-when-let (docstring (helpful--docstring helpful--sym helpful--callable-p))
       (helpful--insert-section-break)
       (insert
-       (helpful--heading (format "%s Documentation" (cond
-                                                     ((not helpful--callable-p)
-                                                      "Variable")
-                                                     ((macrop helpful--sym)
-                                                      "Macro")
-                                                     (t
-                                                      "Function"))))
+       (helpful--heading (format "%s Documentation" sym-type))
        (helpful--format-docstring docstring))
       (when (helpful--in-manual-p helpful--sym)
         (insert

--- a/helpful.el
+++ b/helpful.el
@@ -916,27 +916,23 @@ state of the current symbol."
 
     (if helpful--callable-p
         (insert
-         (helpful--heading
-          (if (macrop helpful--sym)
-              "Macro Signature\n"
-            "Function Signature\n"))
+         (helpful--heading (format "%s Signature\n"
+                                   (if (macrop helpful--sym) "Macro" "Function")))
          (helpful--syntax-highlight (helpful--signature helpful--sym)))
       (insert
-       (helpful--heading
-        "Variable\n")
+       (helpful--heading "Variable\n")
        (symbol-name helpful--sym)))
 
     (-when-let (docstring (helpful--docstring helpful--sym helpful--callable-p))
       (helpful--insert-section-break)
       (insert
-       (helpful--heading
-        (cond
-         ((not helpful--callable-p)
-          "Variable Documentation\n")
-         ((macrop helpful--sym)
-          "Macro Documentation\n")
-         (t
-          "Function Documentation\n")))
+       (helpful--heading (format "%s Documentation\n" (cond
+                                                       ((not helpful--callable-p)
+                                                        "Variable")
+                                                       ((macrop helpful--sym)
+                                                        "Macro")
+                                                       (t
+                                                        "Function"))))
        (helpful--format-docstring docstring))
       (when (helpful--in-manual-p helpful--sym)
         (insert
@@ -1087,8 +1083,7 @@ state of the current symbol."
      (cond
       (source-path
        (concat
-        (propertize
-         (if primitive-p "// Defined in " ";; Defined in ")
+        (propertize (format "%s Defined in " (if primitive-p "//" ";;"))
          'face 'font-lock-comment-face)
         (helpful--navigate-button
          source-path


### PR DESCRIPTION
I was messing with the display in `helpful-update` and figured the changes might be worth keeping. What I'd like is for `helpful-update` to have fewer low-level details -- something along the lines of "insert the signature, then insert the documentation, then insert this or that, then insert the source code" and so on, with the specifics of each section farmed out to separate functions. I don't know if that matches your tastes, but I think it would make the whole thing easier to work with.

If you like the idea I can press forward with more changes (probably in a few separate PRs to avoid merge conflicts).