### PR TITLE
Fix helpful--keymap-keys to handle smerge-mode-map

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -716,6 +716,8 @@ vector suitable for `key-description', and COMMAND is a smbol."
    ;; we can call.
    ((symbolp keymap)
     `(([] ,keymap)))
+   ((stringp (car keymap))
+    (helpful--keymap-keys (cdr keymap)))
    ;; Otherwise, recurse on the keys at this level of the keymap.
    (t
     (let (result)

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -479,6 +479,23 @@ associated a lambda with a keybinding."
         ([17] forward-line)
         ([97] forward-char))))))
 
+(ert-deftest helpful--keymap-keys--strings ()
+  "Test that we handle maps with format (TYPE ITEM-NAME . BINDING)."
+  ;; This is an actual piece of smerge-mode-map.
+  (let ((keymap '(keymap (3 keymap
+                            (94 keymap
+                                (61 keymap
+                                    (61 "upper-lower" . smerge-diff-upper-lower)
+                                    (62 "base-lower" . smerge-diff-base-lower)
+                                    (60 "base-upper" . smerge-diff-base-upper)
+                                    "Diff"))))))
+    (should
+     (equal
+      (helpful--keymap-keys keymap)
+      '(([3 94 61 61] smerge-diff-upper-lower)
+        ([3 94 61 62] smerge-diff-base-lower)
+        ([3 94 61 60] smerge-diff-base-upper))))))
+
 (defun helpful--dummy-command ()
   (interactive))
 


### PR DESCRIPTION
According to the Elisp manual, a keymap can contain a binding of the
form (TYPE ITEM-NAME . BINDING). helpful wasn't checking for that
form, so it crashed for maps like smerge-mode which contain it.

The manual also mentions a few other forms, including
(TYPE ITEM-NAME HELP-STRING . BINDING). I haven't come across that,
and this fix wouldn't handle it. Personally, I'd prefer to deal with
the weird cases as they arise, as having a concrete instance gives me
more confidence that the code handles it correctly.