### PR TITLE
Skip running find-file-hook

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1102,6 +1102,8 @@ buffer."
          (buf nil)
          (pos nil)
          (opened nil)
+         ;; Skip running find-file-hook since it may prompt the user.
+         (find-file-hook nil)
          ;; If we end up opening a buffer, don't bother with file
          ;; variables. It prompts the user, and we discard the buffer
          ;; afterwards anyway.


### PR DESCRIPTION
This is helpful since `find-file-hook` entries often have the potential to prompt the user, but none are necessary for `helpful` to work.