### PR TITLE
Improve helpful--key-sequence performance

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1216,7 +1216,7 @@ buffer."
          (push sym keymaps))))
     keymaps))
 
-(defun helpful--key-sequences (command-sym keymap)
+(defun helpful--key-sequences (command-sym keymap global-keycodes)
   "Return all the key sequences of COMMAND-SYM in KEYMAP."
   (let* ((keycodes
           ;; Look up this command in the keymap, its parent and the
@@ -1232,8 +1232,7 @@ buffer."
          ;; Look up this command in the global map.
          (global-keycodes
           (unless (eq keymap global-map)
-            (where-is-internal
-             command-sym (list global-map) nil t))))
+            global-keycodes)))
     (->> keycodes
          ;; Ignore keybindings from the parent or global map.
          (--remove (or (-contains-p global-keycodes it)
@@ -1255,11 +1254,13 @@ from parent keymaps.
 same bindings as `global-map'."
   (let* ((keymap-syms (helpful--all-keymap-syms))
          (keymap-sym-vals (-map #'symbol-value keymap-syms))
+         (global-keycodes (where-is-internal
+                           command-sym (list global-map) nil t))
          matching-keymaps)
     ;; Look for this command in all keymaps bound to variables.
     (-map
      (-lambda ((keymap-sym . keymap))
-       (let ((key-sequences (helpful--key-sequences command-sym keymap)))
+       (let ((key-sequences (helpful--key-sequences command-sym keymap global-keycodes)))
          (when (and key-sequences (not (eq keymap-sym 'widget-global-map)))
            (push (cons (symbol-name keymap-sym) key-sequences)
                  matching-keymaps))))
@@ -1272,7 +1273,7 @@ same bindings as `global-map'."
        ;; Only consider this keymap if we didn't find it bound to a variable.
        (when (and (keymapp keymap)
                   (not (memq keymap keymap-sym-vals)))
-         (let ((key-sequences (helpful--key-sequences command-sym keymap)))
+         (let ((key-sequences (helpful--key-sequences command-sym keymap global-keycodes)))
            (when key-sequences
              (push (cons (format "minor-mode-map-alist (%s)" minor-mode)
                          key-sequences)

--- a/helpful.el
+++ b/helpful.el
@@ -1236,8 +1236,8 @@ buffer."
              command-sym (list global-map) nil t))))
     (->> keycodes
          ;; Ignore keybindings from the parent or global map.
-         (--remove (-contains-p parent-keycodes it))
-         (--remove (-contains-p global-keycodes it))
+         (--remove (or (-contains-p global-keycodes it)
+                       (-contains-p parent-keycodes it)))
          ;; Convert raw keycode vectors into human-readable strings.
          (-map #'key-description))))
 

--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -543,7 +543,15 @@ associated a lambda with a keybinding."
     2))
 
   ;; Undo keybinding.
-  (global-set-key (kbd "C-c M-S-c") nil))
+  (global-set-key (kbd "C-c M-S-c") nil)
+
+  ;; Check for ido command remapping.
+  (ido-mode 1)
+  (should
+   (equal
+    (helpful--keymaps-containing 'ido-find-file)
+    '(("minor-mode-map-alist (ido-mode)" "<open>" "C-x C-f"))))
+  (ido-mode 0))
 
 (ert-deftest helpful--source ()
   (-let* (((buf pos opened) (helpful--definition #'helpful--source t))


### PR DESCRIPTION
After the success of https://github.com/Wilfred/helpful/pull/132, I thought it
might be fun to try to find more `helpful` performance improvements.
It turns out that `helpful--key-sequences` was a major hotspot.

The first two commits make minor tweaks in the body of
`helpful--key-sequences`. They wouldn't be of any consequence in a
typical function, but because they're in a hotspot, I think they do
make a difference.

The third commit is the big one. `helpful--key-sequences` gets mapped
over a long list of keymaps, and on every call it was generating a
list of global map keycodes for its symbol. But this list of keycodes
is the same every time, so there's no need to keep generating it.
Getting this list once and passing it into the map calls makes a huge
difference in performance in both speed and memory.

To measure, I used this function:

```
(defun helpful-benchmark ()
  (interactive)
  (benchmark 50 '(helpful-callable #'move-beginning-of-line)))
```

Just to be safe, I benchmarked before and after over the course of
several computer seances:

#### Before
```
  Elapsed time: 56.672061s (21.927753s in 160 GCs)
  Elapsed time: 58.963714s (23.069360s in 171 GCs)
  Elapsed time: 56.702608s (22.232472s in 155 GCs)
  Elapsed time: 55.452360s (19.637100s in 150 GCs)
```

#### After
```
  Elapsed time: 29.617945s (11.067265s in 72 GCs)
  Elapsed time: 26.197627s (8.385313s in 59 GCs)
  Elapsed time: 29.024914s (11.277491s in 78 GCs)
  Elapsed time: 28.599935s (10.094264s in 65 GCs)
```

So, it looks about a 50% speed improvement!

(Times were recorded on my crappy little Thinkpad.
`GNU Emacs 26.1.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.22.30) of 2018-06-25`)
