### PR TITLE
Add failing helpful--primitive-p test

### DIFF
--- a/test/unit-test.el
+++ b/test/unit-test.el
@@ -118,6 +118,12 @@ symbol (not a form)."
   ;; Defined in elisp.
   (should (not (helpful--primitive-p 'when t))))
 
+(ert-deftest helpful--primitive-p-fail ()
+  :expected-result :failed
+  ;; `rename-buffer' is primitive, but it's advised (by uniquify), and
+  ;; this confuses `helpful--primitive-p'.
+  (should (helpful--primitive-p 'rename-buffer t)))
+
 (ert-deftest helpful-callable ()
   ;; We should not crash when looking at macros.
   (helpful-callable 'when)


### PR DESCRIPTION
The summary given by (helpful-callable 'rename-buffer) is

  rename-buffer is an interactive function without a source file.

Needless to say, this is not correct. The problem stems from
helpful--primitive-p's inability to handle advised primitive
functions.