### PR TITLE
Syntax-highlight variable value

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1791,7 +1791,7 @@ state of the current symbol."
            (t "Value")))
          (cond
           (helpful--view-literal
-           (helpful--pretty-print val))
+           (helpful--syntax-highlight (helpful--pretty-print val)))
           ;; Allow strings to be viewed with properties rendered in
           ;; Emacs, rather than as a literal.
           ((stringp val)


### PR DESCRIPTION
This makes it a little easier to read, especially in weird cases like

  Value
  ((((3)
     4)
    5
    (6))
   7 8 9 nil nil nil)