### PR TITLE
Sort callees

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -603,7 +603,9 @@ overrides that to include previously opened buffers."
           (if (stringp raw-source)
               (read raw-source)
             raw-source))
-         (syms (helpful--sort-symbols (helpful--callees source))))
+         (syms (helpful--sort-symbols (helpful--callees source)))
+         (primitives (-filter (lambda (sym) (helpful--primitive-p sym t)) syms))
+         (compounds (-remove (lambda (sym) (helpful--primitive-p sym t)) syms)))
 
     (pop-to-buffer buf)
     (let ((inhibit-read-only t))
@@ -611,7 +613,7 @@ overrides that to include previously opened buffers."
       (insert
        ;; TODO: Macros used, special forms used, global vars used.
        (format "Functions called by %s:\n\n" sym))
-      (dolist (sym syms)
+      (dolist (sym compounds)
         (insert "  "
                 (helpful--button
                  (symbol-name sym)
@@ -619,7 +621,21 @@ overrides that to include previously opened buffers."
                  'symbol sym
                  'callable-p t)
                 "\n"))
+
+      (insert "\n")
+
+      (insert (format "Primitives called by %s:\n\n" sym))
+      (dolist (sym primitives)
+        (insert "  "
+                (helpful--button
+                 (symbol-name sym)
+                 'helpful-describe-exactly-button
+                 'symbol sym
+                 'callable-p t)
+                "\n"))
+
       (goto-char (point-min))
+
       ;; TODO: define our own mode, so we can move between links
       ;; conveniently.
       (special-mode))))

--- a/helpful.el
+++ b/helpful.el
@@ -179,6 +179,12 @@ press \\[keyboard-quit] to gracefully stop the printing."
      (propertize "(User quit during pretty-printing.)"
                  'face 'font-lock-comment-face))))
 
+(defun helpful--sort-symbols (sym-list)
+  "Sort symbols in SYM-LIST alphabetically."
+  (--sort
+   (string< (symbol-name it) (symbol-name other))
+   sym-list))
+
 (defun helpful--button (text type &rest properties)
   ;; `make-text-button' mutates our string to add properties. Copy
   ;; TEXT to prevent mutating our arguments, and to support 'pure'
@@ -218,9 +224,7 @@ Return SYM otherwise."
               ;; Don't include SYM.
               (not (eq sym s)))
          (push s aliases))))
-    (--sort
-     (string< (symbol-name it) (symbol-name other))
-     aliases)))
+    (helpful--sort-symbols aliases)))
 
 (defun helpful--format-alias (sym callable-p)
   (let ((obsolete-info (if callable-p
@@ -599,11 +603,7 @@ overrides that to include previously opened buffers."
           (if (stringp raw-source)
               (read raw-source)
             raw-source))
-         (syms (helpful--callees source)))
-    (setq syms
-          (--sort
-           (string< (symbol-name it) (symbol-name other))
-           syms))
+         (syms (helpful--sort-symbols (helpful--callees source))))
 
     (pop-to-buffer buf)
     (let ((inhibit-read-only t))

--- a/helpful.el
+++ b/helpful.el
@@ -594,6 +594,17 @@ overrides that to include previously opened buffers."
   'follow-link t
   'help-echo "Find the functions called by this function/macro")
 
+(defun helpful--display-callee-group (callees)
+  "Insert every entry in CALLEES."
+  (dolist (sym (helpful--sort-symbols callees))
+    (insert "  "
+            (helpful--button
+             (symbol-name sym)
+             'helpful-describe-exactly-button
+             'symbol sym
+             'callable-p t)
+            "\n")))
+
 (defun helpful--show-callees (button)
   "Find all the references to the symbol that this BUTTON represents."
   (let* ((buf (get-buffer-create "*helpful callees*"))
@@ -603,36 +614,22 @@ overrides that to include previously opened buffers."
           (if (stringp raw-source)
               (read raw-source)
             raw-source))
-         (syms (helpful--sort-symbols (helpful--callees source)))
+         (syms (helpful--callees source))
          (primitives (-filter (lambda (sym) (helpful--primitive-p sym t)) syms))
          (compounds (-remove (lambda (sym) (helpful--primitive-p sym t)) syms)))
 
     (pop-to-buffer buf)
     (let ((inhibit-read-only t))
       (erase-buffer)
-      (insert
+
        ;; TODO: Macros used, special forms used, global vars used.
-       (format "Functions called by %s:\n\n" sym))
-      (dolist (sym compounds)
-        (insert "  "
-                (helpful--button
-                 (symbol-name sym)
-                 'helpful-describe-exactly-button
-                 'symbol sym
-                 'callable-p t)
-                "\n"))
+      (insert (format "Functions called by %s:\n\n" sym))
+      (helpful--display-callee-group compounds)
 
       (insert "\n")
 
       (insert (format "Primitives called by %s:\n\n" sym))
-      (dolist (sym primitives)
-        (insert "  "
-                (helpful--button
-                 (symbol-name sym)
-                 'helpful-describe-exactly-button
-                 'symbol sym
-                 'callable-p t)
-                "\n"))
+      (helpful--display-callee-group primitives)
 
       (goto-char (point-min))
 


### PR DESCRIPTION
```
Functions called by fill-paragraph:

  fill-comment-paragraph
  fill-forward-paragraph
  fill-region
  fill-region-as-paragraph
  move-to-left-margin

Primitives called by fill-paragraph:

  =
  barf-if-buffer-read-only
  buffer-hash
  buffer-modified-p
  concat
  current-buffer
  eq
  equal
  funcall
  goto-char
  list
  minibufferp
  not
  point
  point-min
  region-beginning
  region-end
  save-excursion
  set-buffer-modified-p
```

There are more elaborate ways to do this, but it's a start.