### PR TITLE
Add support for named keyboard macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v0.14 (unreleased)
 
+Named keyboard macros are now supported.
+
 Function callees are now sorted.
 
 Fixed an issue where source code of primitive variables included the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v0.14 (unreleased)
 
+Function callees are now sorted.
+
 Fixed an issue where source code of primitive variables included the
 whole surrounding function. This was less useful and significantly
 slower.

--- a/test/helpful-unit-test.el
+++ b/test/helpful-unit-test.el
@@ -137,7 +137,12 @@ symbol (not a form)."
   ;; We should not crash when looking at macros.
   (helpful-callable 'when)
   ;; Special forms should work too.
-  (helpful-callable 'if))
+  (helpful-callable 'if)
+  ;; Named keyboard macros (strings and vectors).
+  (fset 'aaa "aaa")
+  (helpful-callable 'aaa)
+  (fset 'backspace-return [backspace return])
+  (helpful-callable 'backspace-return))
 
 (ert-deftest helpful-callable--with-C-source ()
   "Smoke test for special forms when we have the Emacs C source loaded."


### PR DESCRIPTION
After recording a keyboard macro, it's possible to name it and use it somewhat like a regular function. I did that for the first time yesterday, and discovered that Helpful couldn't handle it. So this fixes that. I also added a changelog entry for the callee-sorting.