### PR TITLE
Add .rs file extension to helpful--primitive-p

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1482,7 +1482,9 @@ POSITION-HEADS takes the form ((123 (defun foo)) (456 (defun bar)))."
     (let ((filename (find-lisp-object-file-name sym 'defvar)))
       (or (eq filename 'C-source)
           (and (stringp filename)
-               (equal (file-name-extension filename) "c")))))))
+               (let ((ext (file-name-extension filename)))
+                 (or (equal ext "c")
+                     (equal ext "rs")))))))))
 
 (defun helpful--sym-value (sym buf)
   "Return the value of SYM in BUF."


### PR DESCRIPTION
This makes it possible to show variables defined in Rust in Remacs.

In general I don't like the idea of modifying Elisp to accomodate
Remacs, but in this case it seems to be necessary because the "c" is
hardcoded. An alternative approach would be to check whether the file
is an Elisp file, but that would require exhaustively enumerating
possibilities: .el, .el.gz, .elc, and maybe more that I don't know
about. This way seems easier, if less elegant.