### PR TITLE
Cut repeated calls to helpful--aliases

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1380,22 +1380,21 @@ alist with the lists concatenated."
                 l1)))
     (append l1-with-values l2-extra-values)))
 
-(defun helpful--keymaps-containing-aliases (command-sym)
+(defun helpful--keymaps-containing-aliases (command-sym aliases)
   "Return a list of pairs mapping keymap symbols to the
 keybindings for COMMAND-SYM in each keymap.
 
 Includes keybindings for aliases, unlike
 `helpful--keymaps-containing'."
-  (let* ((aliases (helpful--aliases command-sym t))
-         (syms (cons command-sym aliases))
+  (let* ((syms (cons command-sym aliases))
          (syms-keymaps (-map #'helpful--keymaps-containing syms)))
     (-reduce #'helpful--merge-alists syms-keymaps)))
 
-(defun helpful--format-keys (command-sym)
+(defun helpful--format-keys (command-sym aliases)
   "Describe all the keys that call COMMAND-SYM."
   (let (mode-lines
         global-lines)
-    (--each (helpful--keymaps-containing-aliases command-sym)
+    (--each (helpful--keymaps-containing-aliases command-sym aliases)
       (-let [(map . keys) it]
         (dolist (key keys)
           (push
@@ -1862,7 +1861,8 @@ state of the current symbol."
                          (buffer-file-name buf)))
           (references (helpful--calculate-references
                        helpful--sym helpful--callable-p
-                       source-path)))
+                       source-path))
+          (aliases (helpful--aliases helpful--sym helpful--callable-p)))
 
     (erase-buffer)
 
@@ -1963,7 +1963,7 @@ state of the current symbol."
       (helpful--insert-section-break)
       (insert
        (helpful--heading "Key Bindings")
-       (helpful--format-keys helpful--sym)))
+       (helpful--format-keys helpful--sym aliases)))
 
     (helpful--insert-section-break)
 
@@ -2047,13 +2047,12 @@ state of the current symbol."
           (insert " "))
         (insert (helpful--make-forget-button helpful--sym helpful--callable-p))))
 
-    (let ((aliases (helpful--aliases helpful--sym helpful--callable-p)))
-      (when aliases
-        (helpful--insert-section-break)
-        (insert
-         (helpful--heading "Aliases")
-         (s-join "\n" (--map (helpful--format-alias it helpful--callable-p)
-                             aliases)))))
+    (when aliases
+      (helpful--insert-section-break)
+      (insert
+       (helpful--heading "Aliases")
+       (s-join "\n" (--map (helpful--format-alias it helpful--callable-p)
+                           aliases))))
 
     (helpful--insert-section-break)
 

--- a/test/helpful-unit-test.el
+++ b/test/helpful-unit-test.el
@@ -612,7 +612,7 @@ in."
   (global-set-key (kbd "C-c M-S-d") #'helpful--dummy-command-alias)
 
   (unwind-protect
-      (let* ((keymaps (helpful--keymaps-containing-aliases #'helpful--dummy-command))
+      (let* ((keymaps (helpful--keymaps-containing-aliases #'helpful--dummy-command (helpful--aliases 'helpful--dummy-command t)))
              (global-keybindings (cdr (assoc "global-map" keymaps))))
         (should
          (equal global-keybindings (list "C-c M-S-c" "C-c M-S-d"))))


### PR DESCRIPTION
helpful--aliases is expensive, so as usual we'll call it just once at
the beginning of helpful-update. This sacrifices a little elegance for
a significant peformance boost. Here are before and after times
running (helpful-callable #'move-beginning-of-line) 50 times on my
crappy little Thinkpad:

Before:

Elapsed time: 61.507899s (23.391894s in 148 GCs)
Elapsed time: 56.855148s (24.392109s in 133 GCs)
Elapsed time: 58.082409s (25.796263s in 146 GCs)

After:

Elapsed time: 43.519486s (17.412847s in 95 GCs)
Elapsed time: 43.171007s (17.036012s in 92 GCs)
Elapsed time: 44.725709s (18.705316s in 102 GCs)

So the time per call goes from a little over a second to a little
under a second.