### PR TITLE
Prevent error when find-function-C-source-directory is undefined

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1172,7 +1172,8 @@ LIBRARY-NAME takes the form \"foo.el\" , \"foo.el\" or
 \"src/foo.c\".
 
 If .elc files exist without the corresponding .el, return nil."
-  (when (member (f-ext library-name) '("c" "rs"))
+  (when (and find-function-C-source-directory
+             (member (f-ext library-name) '("c" "rs")))
     (setq library-name
           (f-expand library-name
                     (f-parent find-function-C-source-directory))))


### PR DESCRIPTION
Fix an error introduced in 2c8feeb3ff818606b15ca08ad90e2116afef001c that leads to an unhandled errror. Occurs when helpful is called on a c source symbol when the c source directory is not known.

Fixes #185 