### PR TITLE
Handle C-style names in helpful-symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Fixed an issue when viewing `inhibit-read-only`.
 Improved the buffer prompt to be more relevant when inspecting
 buffer-local values.
 
+Added looking up C-style Lisp names.
+
 # v0.15
 
 Fixed a crash on formatting values.

--- a/helpful.el
+++ b/helpful.el
@@ -1687,11 +1687,11 @@ OBJ may be a symbol or a compiled function object."
             "special form"
             'helpful-info-button
             'info-node "(elisp)Special Forms"))
-	  (keyboard-macro-button
-	   (helpful--button
-	    "keyboard macro"
-	    'helpful-info-button
-	    'info-node "(elisp)Keyboard Macros"))
+          (keyboard-macro-button
+           (helpful--button
+            "keyboard macro"
+            'helpful-info-button
+            'info-node "(elisp)Keyboard Macros"))
           (interactive-button
            (helpful--button
             "interactive"
@@ -1740,7 +1740,7 @@ OBJ may be a symbol or a compiled function object."
                       'callable-p callable-p)))
             ((not callable-p) "variable")
             ((macrop sym) "macro")
-	    ((helpful--kbd-macro-p sym) keyboard-macro-button)
+            ((helpful--kbd-macro-p sym) keyboard-macro-button)
             (t "function")))
           (defined
             (cond
@@ -1907,7 +1907,7 @@ state of the current symbol."
        (helpful--format-obsolete-info helpful--sym helpful--callable-p)))
 
     (when (and helpful--callable-p
-	       (not (helpful--kbd-macro-p helpful--sym)))
+               (not (helpful--kbd-macro-p helpful--sym)))
       (helpful--insert-section-break)
       (insert
        (helpful--heading "Signature")
@@ -2222,12 +2222,12 @@ For example, \"(some-func FOO &optional BAR)\"."
      (s-word-wrap
       70
       (format "This %s is obsolete%s%s"
-	      (helpful--kind-name sym callable-p)
-	      (if date (format " since %s" date)
-	        "")
-	      (cond ((stringp use) (concat "; " use))
-    		    (use (format "; use `%s' instead." use))
-    		    (t ".")))))))
+              (helpful--kind-name sym callable-p)
+              (if date (format " since %s" date)
+                "")
+              (cond ((stringp use) (concat "; " use))
+                    (use (format "; use `%s' instead." use))
+                    (t ".")))))))
 
 (defun helpful--docstring (sym callable-p)
   "Get the docstring for SYM.

--- a/test/helpful-unit-test.el
+++ b/test/helpful-unit-test.el
@@ -847,3 +847,17 @@ find the source code."
   (helpful-variable 'inhibit-read-only)
   (should
    (s-contains-p "Value\nnil" (buffer-string))))
+
+(ert-deftest helpful--convert-c-name ()
+  (should
+   (equal
+    'make-string
+    (helpful--convert-c-name 'Fmake_string nil)))
+  (should
+   (equal
+    'gc-cons-percentage
+    (helpful--convert-c-name 'Vgc_cons_percentage t)))
+  (should-not
+   (helpful--convert-c-name 'Fmake_string t))
+  (should-not
+   (helpful--convert-c-name 'Vgc_cons_percentage nil)))


### PR DESCRIPTION
In Emacs's C core, Lisp functions and variables take on slightly
different names: dashes are replaced with underscores, and functions
and variables are prefixed with "F" and "V" respectively. This change
allows for looking up those symbols. For example, if I am looking at
the source for `purecopy':

```c
  DEFUN ("purecopy", Fpurecopy, Spurecopy, 1, 1, 0,
         doc: /* Make a copy of object OBJ in pure storage.
  Recursively copies contents of vectors and cons cells.
  Does not copy symbols.  Copies strings without text properties.  */)
    (register Lisp_Object obj)
  {
    if (NILP (Vpurify_flag))
      return obj;
    else if (MARKERP (obj) || OVERLAYP (obj) || SYMBOLP (obj))
      /* Can't purify those.  */
      return obj;
    else
      return purecopy (obj);
  }
```

I can run `helpful-at-point' on `Vpurify_flag'.

This doesn't support running C-style names through `helpful-callable'
etc, but that doesn't seem like a useful feature.
