### PR TITLE
Remove all advices before determining source of function

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1460,7 +1460,7 @@ E.g. (x x y z y) -> ((x . 2) (y . 2) (z . 1))"
 (defun helpful--without-advice (sym)
   "Given advised function SYM, return the function object
 without the advice."
-  (advice--cdr
+  (advice--cd*r
    (advice--symbol-function sym)))
 
 (defun helpful--advised-p (sym)


### PR DESCRIPTION
There is a bug in helpful where it will only remove the outermost advice, this leads functions being mistakenly marked as non-primitive.

This bug is hard to source because a function must have multiple layers of advices and `find-function-C-source-directory` must be nil for the issue to manifest. 

closes #185 
closes #187 