### PR TITLE
Add hide docstring functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Helpful will try really hard to show the source code. It shows the
 source code for interactively defined functions (unlike the built-in
 Help) and falls back to the raw sexp if no source is available.
 
+Set `helpful-hide-docstring-in-source` to hide the docstring in source
+code.
+
 ### View Callers
 
 ![screenshot](screenshots/helpful_refs.png)

--- a/helpful.el
+++ b/helpful.el
@@ -94,6 +94,15 @@ To disable cleanup entirely, set this variable to nil. See also
   :type 'function
   :group 'helpful)
 
+(defcustom helpful-hide-docstring-in-source nil
+  "If t, hide the the docstring source code header.
+
+This is useful because the formated documentation is already
+displayed in it's own header, and you may not want to display it
+twice."
+  :type 'boolean
+  :group 'helpful)
+
 ;; TODO: explore whether more basic highlighting is fast enough to
 ;; handle larger functions. See `c-font-lock-init' and its use of
 ;; font-lock-keywords-1.
@@ -1118,6 +1127,14 @@ hooks.")
 (defun helpful--syntax-highlight (source &optional mode)
   "Return a propertized version of SOURCE in MODE."
   (unless mode
+    (when helpful-hide-docstring-in-source
+      (let ((doc-string (nth 3 (ignore-errors
+                                 (read source)))))
+        (when (stringp doc-string)
+          (setq source
+                (replace-regexp-in-string
+                 (regexp-quote (prin1-to-string doc-string))
+                 "\"...DOCSTRING...\"" source t t)))))
     (setq mode #'emacs-lisp-mode))
   (if (or
        (< (length source) helpful-max-highlight)


### PR DESCRIPTION
Some function and variables (like `ivy-read` or `company-backends`) have very large docstrings. These are nicely formatted in the Documentation heading, but then when you get done reading that, you see the same thing show up again in the `Source Code` heading. There really isn't a need to show the docstring twice, so I added a variable that will remove the docstring from the source code section. I tested it with many different symbols and the only place it does not work is when the docstring adds escapes to non-meta characters (like `(` and `)`). 