### PR TITLE
Add support for CL generic methods

### DIFF
--- a/test/helpful-unit-test.el
+++ b/test/helpful-unit-test.el
@@ -1042,3 +1042,10 @@ find the source code."
      70
      "This variable was added, or its default value changed, in helpful version 1.2.3.")
     (buffer-string))))
+
+(ert-deftest helpful--display-implementations ()
+  (require 'xref)
+  (helpful-function 'xref-location-marker)
+  (should (s-contains-p "Implementations" (buffer-string)))
+  (should (s-contains-p "((l xref-file-location))" (buffer-string)))
+  (should (s-contains-p "((l xref-buffer-location))" (buffer-string))))


### PR DESCRIPTION
```emacs
(progn
  (require 'xref)
  (helpful-function #'xref-location-marker))
```

Will give you the list of implementation for this generic method.
