### PR TITLE
better helpful-at-point

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -2657,7 +2657,9 @@ See also `helpful-callable' and `helpful-variable'."
 (defun helpful-at-point ()
   "Show help for the symbol at point."
   (interactive)
-  (-if-let (symbol (symbol-at-point))
+  (-if-let (symbol (or (unless (numberp (variable-at-point)) (variable-at-point))
+  		       (if (symbolp (symbol-at-point)) (symbol-at-point))
+  		       (function-called-at-point)))
       (helpful-symbol symbol)
     (user-error "There is no symbol at point.")))
 


### PR DESCRIPTION
I always bothered me that `helpful-at-point` did not work in my literate org mode emacs config.
This might be because org-mode does not or can't implement the meaning of a symbol correctly.
eg `'function-a` inside a org-mode SRC block is not correctly recognized.

#163 pointed me to `variable-at-point` and `function-called-at-point` and I tried to use them.
I think it works better now but let me know if you have issues with it.