### PR TITLE
Add example of using `define-key` with `help-command`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ so:
 (global-set-key (kbd "C-h k") #'helpful-key)
 ```
 
+Alternatively, to replace the default functions with Helpful versions
+everwhere the help command is used (by default, `C-h` and `F1`) you
+can do:
+
+``` emacs-lisp
+(define-key 'help-command "f" 'helpful-callable)
+
+(define-key 'help-command "v" 'helpful-variable)
+(define-key 'help-command "k" 'helpful-key)
+```
+
 I also recommend the following keybindings to get the most out of
 helpful:
 


### PR DESCRIPTION
Hello,

Would you consider adding this example to the README? I make heavy use of nested keymaps in my config, so the current example did not work well, and when I went to replace the default keys in help command's map it does not seem to follow the normal pattern I expect. Most of the time `define-key` calls look like:

``` emacs-lisp
(define-key Buffer-menu-mode-map " " saff-map)
```

But when replacing keys for help command, the first argument is supposed to be the symbol `'help-command` instead of a keymap:

``` emacs-lisp
(define-key 'help-command "k" 'helpful-key)
```

This was confusing and frustrating at first and an example in the README would have made the integration process go a lot more smoothly.

Incidentally, it is not clear to me why passing in a symbol works here, when it needs to be a keymap value everywhere else. If you have any insight into this I would appreciate hearing why.

Thanks,
Bryan