### PR TITLE
Prevent error in helpful-variable if sexp at point can't be read

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -2738,7 +2738,9 @@ See also `helpful-callable' and `helpful-variable'."
              sexp)
         (when sexp-start
           (goto-char sexp-start)
-          (setq sexp (read (current-buffer)))
+          (setq sexp (condition-case nil
+                         (read (current-buffer))
+                       (error nil)))
           (when (memq (car-safe sexp)
                       (list 'defvar 'defvar-local 'defcustom 'defconst))
             (nth 1 sexp)))))))


### PR DESCRIPTION
How to reproduce from emacs -Q in the \*scratch\* buffer:

0. If needed, do `(package-initialize)` and `(require 'helpful)`.
1. Type `(something some-undefined-variable|` where | represents
   point.  (Note that there is no closing parenthesis!)
2. Call helpful-variable.

This will give you an `End of file during parsing` from
`helpful--variable-defined-at-point` because the sexp at point can't
be read due to the missing parenthesis.  This commit suppresses the
error and should therefore fix #251.