### PR TITLE
`helpful-describe-variable': support `nil'

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -2132,7 +2132,6 @@ value is different."
   "Update the current *Helpful* buffer to the latest
 state of the current symbol."
   (interactive)
-  (cl-assert (not (null helpful--sym)))
   (unless (buffer-live-p helpful--associated-buffer)
     (setq helpful--associated-buffer nil))
   (helpful--ensure-loaded)


### PR DESCRIPTION
`helpful-describe-variable` asserts that `helpful--sym` is non-nil. However,
`nil` is also a variable, and `describe-variable` works with it. Drop the
`cl-assert` causing the issue.

----

#