### PR TITLE
Add buttons to remove advice

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -2257,6 +2257,22 @@ state of the current symbol."
           (insert "\n\n")
           (insert (helpful--make-manual-button helpful--sym)))))
 
+    (when (helpful--advised-p helpful--sym)
+      (helpful--insert-section-break)
+      (insert (helpful--heading "Advice"))
+      (dolist (x (helpful--get-advice helpful--sym))
+        (cl-destructuring-bind (combinator . advice) x
+          (insert (propertize (symbol-name combinator) 'face 'font-lock-builtin-face)
+                  " "
+                  (helpful--button
+                   (symbol-name advice) 'helpful-describe-button
+                   'symbol advice
+                   'callable-p t)
+                  "\n")))
+      ;; We've inserted one newline too many, since the next section will insert
+      ;; a section break.
+      (delete-char -1))
+
     ;; Show keybindings.
     ;; TODO: allow users to conveniently add and remove keybindings.
     (when (commandp helpful--sym)
@@ -2300,22 +2316,6 @@ state of the current symbol."
       (insert
        " "
        (helpful--make-callees-button helpful--sym source)))
-
-    (when (helpful--advised-p helpful--sym)
-      (helpful--insert-section-break)
-      (insert (helpful--heading "Advice"))
-      (dolist (x (helpful--get-advice helpful--sym))
-        (cl-destructuring-bind (combinator . advice) x
-          (insert (propertize (symbol-name combinator) 'face 'font-lock-builtin-face)
-                  " "
-                  (helpful--button
-                   (symbol-name advice) 'helpful-describe-button
-                   'symbol advice
-                   'callable-p t)
-                  "\n")))
-      ;; We've inserted one newline too many, since the next section will insert
-      ;; a section break.
-      (delete-char -1))
 
     (let ((can-edebug
            (helpful--can-edebug-p helpful--sym helpful--callable-p buf pos))

--- a/helpful.el
+++ b/helpful.el
@@ -1115,6 +1115,16 @@ unescaping too."
   'follow-link t
   'help-echo "Follow this link")
 
+(defun helpful--remove-advice (button)
+  "Remove advice for BUTTON."
+  (advice-remove (button-get button 'symbol)
+                 (button-get button 'advice))
+  (helpful-update))
+
+(define-button-type 'helpful-remove-advice-button
+  'action #'helpful--remove-advice
+  'help-echo "Remove advice")
+
 (defun helpful--propertize-links (docstring)
   "Convert URL links in docstrings to buttons."
   (replace-regexp-in-string
@@ -2262,7 +2272,11 @@ state of the current symbol."
       (insert (helpful--heading "Advice"))
       (dolist (x (helpful--get-advice helpful--sym))
         (cl-destructuring-bind (combinator . advice) x
-          (insert (propertize (symbol-name combinator) 'face 'font-lock-builtin-face)
+          (insert (helpful--button "X" 'helpful-remove-advice-button
+                                   'symbol helpful--sym
+                                   'advice advice)
+                  " "
+                  (propertize (symbol-name combinator) 'face 'font-lock-builtin-face)
                   " "
                   (helpful--button
                    (symbol-name advice) 'helpful-describe-button
@@ -2434,7 +2448,8 @@ state of the current symbol."
 
 ;; TODO: this isn't sufficient for `edebug-eval-defun'.
 (defun helpful--skip-advice (docstring)
-  "Remove mentions of advice from DOCSTRING."
+  "Remove mentions of advice from DOCSTRING.
+The resulting DOCSTRING might start with a blank newline."
   (with-temp-buffer
     (insert docstring)
     (goto-char (point-min))


### PR DESCRIPTION
- `helpful--skip-advice` now works for non `:around` advice. This means that the
  docstring no longer displays any advice.
- The `Advice` section no longer just says "This function is advised", but now
  lists the advice, one per line, with the format `<clickable X to remove>
  :<before/after/...> <advice symbol>`:
  ```emacs-lisp
  X :before +whatever
  X :after +whatever
  ```

----

#