### PR TITLE
Unescape \= in signature docstring

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -2500,7 +2500,8 @@ For example, \"(some-func FOO &optional BAR)\"."
       source-sig)
      ;; If that's not set, use the usage specification in the
      ;; docstring, if present.
-     (docstring-sig)
+     (docstring-sig
+      (replace-regexp-in-string "\\\\=\\(['\\`‘’]\\)" "\\1" docstring-sig t))
      (t
       ;; Otherwise, just use the signature from the source code.
       source-sig))))


### PR DESCRIPTION
`helpful--signature`: unquote \=, as added by `help--quote-signature`.

An example where this is needed is `\(setf\ seq-elt\)`, which used to be
displayed as `(\=\(setf\=\ seq-elt\=\)` (now `(\(setf\ seq-elt\) ARG0 ARG &rest
ARGS)`, as with `describe-function`).


----

#