### PR TITLE
Assign `list-buffers-directory` to help topic

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -149,6 +149,8 @@ can make Helpful very slow.")
       (setq helpful--callable-p callable-p)
       (setq helpful--start-buffer current-buffer)
       (setq helpful--associated-buffer current-buffer)
+      (setq list-buffers-directory
+        (if (symbolp symbol) (format "%s: %s" (helpful--kind-name symbol callable-p) symbol) "lambda"))
       (if (helpful--primitive-p symbol callable-p)
           (setq-local comment-start "//")
         (setq-local comment-start ";")))


### PR DESCRIPTION
This displays the help topic in `M-x list-buffers` instead of showing an
empty path column.

I copied these lines from the `(interactive)` form above. It might be worth
extracting this into a function.