### PR TITLE
Change "compiled" to "byte-compiled"

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1898,7 +1898,7 @@ OBJ may be a symbol or a compiled function object."
             'info-node "(elisp)Autoload"))
           (compiled-button
            (helpful--button
-            "compiled"
+            "byte-compiled"
             'helpful-info-button
             'info-node "(elisp)Byte Compilation"))
           (native-compiled-button


### PR DESCRIPTION
With the introduction of native compilation, this change makes the
distinction between it and byte-compilation clearer.

https://akrl.sdf.org/gccemacs.html

This is also a follow-up on 
https://github.com/Wilfred/helpful/pull/240#issuecomment-624507648