### PR TITLE
Fix `helpful--autoloaded-p` in Emacs 29.0.50

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1837,7 +1837,7 @@ OBJ may be a symbol or a compiled function object."
   "Return non-nil if function SYM is autoloaded."
   (-when-let (file-name (buffer-file-name buf))
     (setq file-name (s-chop-suffix ".gz" file-name))
-    (help-fns--autoloaded-p sym file-name)))
+    (help-fns--autoloaded-p sym)))
 
 (defun helpful--compiled-p (sym)
   "Return non-nil if function SYM is byte-compiled"
@@ -2434,9 +2434,9 @@ state of the current symbol."
   "Remove mentions of advice from DOCSTRING."
   (let* ((lines (s-lines docstring))
          (relevant-lines
-          (--drop-while
-           (or (s-starts-with-p ":around advice:" it)
-               (s-starts-with-p "This function has :around advice:" it))
+          (--take-while
+           (not (or (s-starts-with-p ":around advice:" it)
+                    (s-starts-with-p "This function has :around advice:" it)))
            lines)))
     (s-trim (s-join "\n" relevant-lines))))
 

--- a/helpful.el
+++ b/helpful.el
@@ -1837,7 +1837,11 @@ OBJ may be a symbol or a compiled function object."
   "Return non-nil if function SYM is autoloaded."
   (-when-let (file-name (buffer-file-name buf))
     (setq file-name (s-chop-suffix ".gz" file-name))
-    (help-fns--autoloaded-p sym)))
+    (condition-case nil
+        (help-fns--autoloaded-p sym file-name)
+      ; new in Emacs 29.0.50
+      ; see https://github.com/Wilfred/helpful/pull/283
+      (error (help-fns--autoloaded-p sym)))))
 
 (defun helpful--compiled-p (sym)
   "Return non-nil if function SYM is byte-compiled"
@@ -2434,9 +2438,9 @@ state of the current symbol."
   "Remove mentions of advice from DOCSTRING."
   (let* ((lines (s-lines docstring))
          (relevant-lines
-          (--take-while
-           (not (or (s-starts-with-p ":around advice:" it)
-                    (s-starts-with-p "This function has :around advice:" it)))
+          (--drop-while
+           (or (s-starts-with-p ":around advice:" it)
+               (s-starts-with-p "This function has :around advice:" it))
            lines)))
     (s-trim (s-join "\n" relevant-lines))))
 


### PR DESCRIPTION
I don't know how (or whether to) add this change, since it likely breaks `helpful` for anyone not using the latest Emacs. What to do?

## `help-fns--autoloaded-p`

The function `help-fns--autoloaded-p` now only takes 1 argument, so `describe-function` errors out; as described in hlissner/doom-emacs#6097 . The change was made on [2022-01-31](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=1d1b664fbb9232aa40d8daa54a689cfd63d38aa9).


## `helpful--skip-advice`

Also fixed `helpful--skip-advice`. The advice info is now appended to the
documentation, so the test `helpful--docstring-advice` would fail.

That is, the docstring from `(documentation #'test-foo-advised t)` now reads:

```
"Docstring here too.

This function has :around advice: ‘ad-Advice-test-foo-advised’.

(fn)"
```
