### PR TITLE
Fix advised function docstring test

### DIFF
--- a/test/helpful-unit-test.el
+++ b/test/helpful-unit-test.el
@@ -119,7 +119,7 @@ bar")))
   (should
    (equal
     (helpful--docstring #'test-foo-advised t)
-    "Docstring here too.")))
+    "Docstring here too.\n\nThis function has :around advice: `ad-Advice-test-foo-advised'.")))
 
 (defun test-foo-no-docstring ()
   nil)

--- a/test/helpful-unit-test.el
+++ b/test/helpful-unit-test.el
@@ -119,7 +119,9 @@ bar")))
   (should
    (equal
     (helpful--docstring #'test-foo-advised t)
-    "Docstring here too.\n\nThis function has :around advice: `ad-Advice-test-foo-advised'.")))
+    (if (version< emacs-version "28")
+        "Docstring here too."
+    "Docstring here too.\n\nThis function has :around advice: `ad-Advice-test-foo-advised'."))))
 
 (defun test-foo-no-docstring ()
   nil)


### PR DESCRIPTION
The helpful--docstring function correctly reports that a function has advice.
This test expected that advice would be ignored.