### PR TITLE
Support viewing help for unbound symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v0.20 (unreleased)
 
+Fixed an issue where advised functions are treated as primitives if
+they have been native-compiled (#295).
+
+Added support for viewing help for symbols not bound as variables or
+functions.
+
 # v0.19 (released 12th May 2022)
 
 Fixed a hang when looking at functions that had advice but hadn't yet

--- a/test/helpful-unit-test.el
+++ b/test/helpful-unit-test.el
@@ -505,6 +505,10 @@ buffers lying around."
     "function"))
   (should
    (equal
+    (helpful--kind-name 'file-missing nil)
+    "unbound symbol"))
+  (should
+   (equal
     (helpful--kind-name 'save-excursion t)
     "special form")))
 


### PR DESCRIPTION
An unbound symbol can still have symbol properties. Without this, it is painful to eg. look for where a button type or a face is defined.

The way I merged the display of unbound symbols into the rest of helpful-update seems... inelegant, but avoiding that would require rearchitecting helpful-update to delegate to different "views" instead, so I've opted to not do that for now.

<img src="https://user-images.githubusercontent.com/11722318/177780210-872d9b8c-87c9-4edf-8893-2193efbab6e5.png" alt="20220707T220308+0900" width=400>

- `helpful--kind-name`

  Return "unbound symbol" for symbols that are neither bound as variables or functions.

  Also added this case to its unit test.

- `helpful--summary`

  Add support for unbound symbols. They are rendered like this: "epg-error is an unbound symbol."

- `helpful--bound-p`

  Return non-nil for a lambda instead of erroring out.

- `helpful-unbound-symbol`

  New command. Functionally the same as helpful-variable when called from Lisp, but offers only unbound symbols with properties for completion.

- `helpful-symbol`

  Call helpful-unbound-symbol for unbound symbols.

- `helpful--update`

  Add support for unbound symbols.

- `helpful--format-references-to-unbound`

  New function. This returns the text for the references section. Because unbound symbols do not have symbol-file, this unfortunately has to resort to searching every loaded file with elisp-refs.

- `CHANGELOG.md`

  Add entry for this change and for #295
