### PR TITLE
Mark symbol in "[the] command <symbol>" as callable

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -797,6 +797,7 @@ bound) or else highlight."
        'callable-p nil))
      ((and (fboundp sym) (or
                           (s-starts-with-p " command" after-txt)
+                          (s-ends-with-p "command " before-txt)
                           (s-ends-with-p "function " before-txt)))
       (helpful--button
        sym-name


### PR DESCRIPTION
This, for example, skips an unnecessary "show variable?" for local minor mode variables.

Whereas recentf-mode (global) says:

> Non-nil if Recentf mode is enabled.
>
> See the recentf-mode command
> for a description of this minor mode.

, whitespace-mode (local) says:

> Non-nil if Whitespace mode is enabled.
>
> Use the command whitespace-mode to change this variable.

. This change catches the latter case.