### PR TITLE
Remove use of (point) as a generalized variable

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1760,7 +1760,7 @@ POSITION-HEADS takes the form ((123 (defun foo)) (456 (defun bar)))."
       (with-temp-buffer
         (declare-function cl--generic-describe "cl-generic" (function))
         (cl--generic-describe func)
-        (setf (point) (point-min))
+        (goto-char (point-min))
         (when (re-search-forward "^Implementations:$" nil t)
           (setq content (buffer-substring (point) (point-max)))))
       (when content


### PR DESCRIPTION
This use has been made obsolete since Emacs 29.

See https://github.com/emacs-mirror/emacs/blob/ca3763af5cc2758ec71700029558e6ecc4379ea9/etc/NEWS#L3177 .