### PR TITLE
Use help-key-binding as face for keystrokes

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -980,7 +980,8 @@ vector suitable for `key-description', and COMMAND is a smbol."
    ;; Text of the form \\[foo-command]
    (rx "\\[" (group (+ (not (in "]")))) "]")
    (lambda (it)
-     (let* ((symbol-name (match-string 1 it))
+     (let* ((button-face (if (>= emacs-major-version 28) 'help-key-binding 'button))
+            (symbol-name (match-string 1 it))
             (symbol (intern symbol-name))
             (key (where-is-internal symbol keymap t))
             (key-description
@@ -991,7 +992,8 @@ vector suitable for `key-description', and COMMAND is a smbol."
         key-description
         'helpful-describe-exactly-button
         'symbol symbol
-        'callable-p t)))
+        'callable-p t
+        'face button-face)))
    str
    t
    t))
@@ -1632,7 +1634,9 @@ Includes keybindings for aliases, unlike
           (push
            (format "%s %s"
                    (propertize map 'face 'font-lock-variable-name-face)
-                   key)
+                   (if (>= emacs-major-version 28)
+                       (propertize key 'face 'help-key-binding)
+                     key))
            (if (eq map 'global-map) global-lines mode-lines)))))
     (setq global-lines (-sort #'string< global-lines))
     (setq mode-lines (-sort #'string< mode-lines))

--- a/test/helpful-unit-test.el
+++ b/test/helpful-unit-test.el
@@ -293,7 +293,16 @@ symbol (not a form)."
      (get-text-property 0 'button formatted)))
   ;; If we have quotes around a key sequence, we should not propertize
   ;; it as the button styling will no longer be visible.
-  (-let [formatted (helpful--format-docstring "`\\[set-mark-command]'")]
+  (-let* ((emacs-major-version 28)
+         (formatted (helpful--format-docstring "`\\[set-mark-command]'")))
+    (should
+     (string-equal formatted "C-SPC"))
+    (should
+     (eq
+      (get-text-property 0 'face formatted)
+      'help-key-binding)))
+  (-let* ((emacs-major-version 27)
+         (formatted (helpful--format-docstring "`\\[set-mark-command]'")))
     (should
      (string-equal formatted "C-SPC"))
     (should


### PR DESCRIPTION
Emacs 28 [introduced](https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS.28?h=master#n619) a new face for keystrokes (`help-key-binding`) which is used both in `*Help*` buffers and tooltips. Thought it might be a good idea if Helpful used it too, it looks nice :smiley: 

Before:

![image](https://user-images.githubusercontent.com/131893/206670388-457c2502-74a2-430d-9658-35dfec1182eb.png)

After:

![image](https://user-images.githubusercontent.com/131893/206670545-4c81ec1c-2e1d-4bb3-a99d-2b6a6b559df2.png)

Note the nicely boxed keystrokes in the `Key Bindings` and `Documentation` sections.

I could create a new face say `helpful-key-binding` inheriting from `help-key-binding` if you want to allow users to customise further.

Thanks for considering this patch.