### PR TITLE
`C-h x` for commands (standard binding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ so:
 
 (global-set-key (kbd "C-h v") #'helpful-variable)
 (global-set-key (kbd "C-h k") #'helpful-key)
+(global-set-key (kbd "C-h x") #'helpful-command)
 ```
 
 I also recommend the following keybindings to get the most out of
@@ -43,13 +44,6 @@ helpful:
 ;; By default, C-h F is bound to `Info-goto-emacs-command-node'. Helpful
 ;; already links to the manual, if a function is referenced there.
 (global-set-key (kbd "C-h F") #'helpful-function)
-
-;; Look up *C*ommands.
-;;
-;; By default, C-h C is bound to describe `describe-coding-system'. I
-;; don't find this very useful, but it's frequently useful to only
-;; look at interactive functions.
-(global-set-key (kbd "C-h C") #'helpful-command)
 ```
 
 [Ivy](https://github.com/abo-abo/swiper) users can use Helpful with


### PR DESCRIPTION
The standard Emacs binding for help with commands is `C-h x`; no need to shadow `C-h C`.