### PR TITLE
Mark customizable variables (user options) in the summary line

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1957,6 +1957,11 @@ OBJ may be a symbol or a compiled function object."
             "special form"
             'helpful-info-button
             'info-node "(elisp)Special Forms"))
+          (user-option-button
+           (helpful--button
+            "customizable"
+            'helpful-info-button
+            'info-node "(elisp)Variable Definitions"))
           (keyboard-macro-button
            (helpful--button
             "keyboard macro"
@@ -2000,6 +2005,8 @@ OBJ may be a symbol or a compiled function object."
             (if (and callable-p (commandp sym)) interactive-button)
             (if compiled-p compiled-button)
             (if native-compiled-p native-compiled-button)
+            (if (and (not callable-p) (custom-variable-p sym))
+                user-option-button)
             (if (and (not callable-p) (local-variable-if-set-p sym))
                 buffer-local-button)))
           (description


### PR DESCRIPTION
User options are variables declared with defcustom. It is useful to know if a variable is a user option or not, because if it isn't, it's usually not safe to set it in the init file.

Calling user options "customizable variables" makes it clear that a user option is still a variable. This is kind of like how interactive functions are not referred to as "commands" in the summary.

![20230107T185248+0900](https://user-images.githubusercontent.com/11722318/211144590-2d78708c-d2a1-4b66-be95-c566c3e8a512.png)
