### PR TITLE
helpful--heading: propertize newline as well, enabling `:extend t`

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -167,7 +167,7 @@ can make Helpful very slow.")
 
 (defun helpful--heading (text)
   "Propertize TEXT as a heading."
-  (format "%s\n" (propertize text 'face 'helpful-heading)))
+  (propertize (concat text "\n") 'face 'helpful-heading))
 
 (defun helpful--format-closure (sym form)
   "Given a closure, return an equivalent defun form."


### PR DESCRIPTION
Prior to this commit, setting attribute :extend of the face helpful--heading to t did not take any effect. This is fixed by this commit by propertizing the newline right after the heading as well.