### PR TITLE
fix nil pos when building button for vars

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1498,7 +1498,7 @@ buffer."
           ;; that.
           (save-excursion
             (condition-case _err
-                (setq pos (cdr (find-variable-noselect sym 'defvar)))
+                (setq pos (cdr (find-variable-noselect sym library-name)))
               (search-failed nil)
               ;; If your current Emacs instance doesn't match the source
               ;; code configured in find-function-C-source-directory, we can


### PR DESCRIPTION
The button link for variables probably have been broken forever. On Emacs 29, when `M-x helpful-variable RET vc-directory-exclusion-list`, the `find-variable-noselect` call will call down to `find-function-search-for-symbol`, and then when trying to `string-match` `'defvar', and error complaining about `'defvar' is not a string will be thrown and `pos` will always be set to `nil`, which mean clicking on the "defined in `vc-hooks.el.gz`" link will only send the user to the top of the file and not the line defining the variable. This PR fixes this issues.