### PR TITLE
Fix wrong-type-argument error in helpful-key

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -2712,7 +2712,7 @@ See also `helpful-function'."
      ((null sym)
       (user-error "No command is bound to %s"
                   (key-description key-sequence)))
-     ((commandp sym)
+     ((commandp sym t)
       (helpful--update-and-switch-buffer sym t))
      (t
       (user-error "%s is bound to %s which is not a command"


### PR DESCRIPTION
Related to #246.

When a key is bound to an anonymous keyboard-macro, `helpful-key` issues a "wrong type argument" error, as described in the linked issue.  For example, if "C-h" is bound to "^?" (to mimic backspace), and one enters "M-x helpful-key C-h", the message will be:

```
Wrong type argument: symbolp, "^?"
```

This pull request causes `helpful-key` to respond with a less confusing error message, like so:

```
C-h is bound to ^? which is not a command
```
