### PR TITLE
handle `package-version` safely to prevent `listp` error

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -1317,8 +1317,8 @@ Return nil otherwise."
        (package-version
         (format
          "This variable was added, or its default value changed, in %s version %s."
-         (car package-version)
-         (cdr package-version)))
+         (or (car-safe package-version) "unknown")
+         (or (cdr-safe package-version) "unknown")))
        (emacs-version
         (format
          "This variable was added, or its default value changed, in Emacs %s."


### PR DESCRIPTION
When `package-version' is not what we expect (e.g a simple string), a `listp` error is thrown and you are unable to view the variable documentation due to it. This now handles it and provides a fallback value.

This was a recurring problem I was facing when opening `which-key` variables using `helpful`. 
`which-key` would send a value of "31.0" and then cause this error: 

`helpful--version-info: Wrong type argument: listp, "1.0"`