### PR TITLE
fix: Improve variable setting logic in helpful.el

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -606,7 +606,9 @@ overrides that to include previously opened buffers."
   (let* ((sym (button-get button 'symbol))
          (buf (button-get button 'buffer))
          (sym-value (helpful--sym-value sym buf))
-         (set-func (symbol-name helpful-set-variable-function))
+         (set-func (if (local-variable-p sym buf)
+                       "setq"
+                     (symbol-name helpful-set-variable-function)))
          ;; Inspired by `counsel-read-setq-expression'.
          (expr
           (minibuffer-with-setup-hook


### PR DESCRIPTION
Hi. I noticed that because of the change I made before to use `setopt`, we are no longer setting variables that are defined locally for the buffer. Now, I have made it so that we use `setq` if the variable is defined locally so that we can set local variables.