### PR TITLE
Use help-fns internal symbol completion table

### DIFF
--- a/helpful.el
+++ b/helpful.el
@@ -2674,7 +2674,10 @@ Returns the symbol."
            (rx ": " eos)
            (format " (default: %s): " default-val)
            prompt)))
-  (intern (completing-read prompt obarray
+  (intern (completing-read prompt
+                           (if (fboundp 'help--symbol-completion-table)
+                               'help--symbol-completion-table
+                             obarray)
                            predicate t nil nil
                            default-val)))
 


### PR DESCRIPTION
This PR came as a result of a package called [llama](https://github.com/tarsius/llama/) that introduced a hacky macro that unfortunately results in an empty string function name that always appear at the top of the completion table.

The details of the problem is described [here](https://github.com/minad/vertico/discussions/481). Essentially, this macro abuses the fact that the empty string can be used as a symbol, which defeats every intuitive string matching and sorting algorithms, and results in an empty string function at the top of the completion table whenever `helpful-callable` or `helpful-macro` is invoked.

[Recent](https://github.com/tarsius/llama/commit/4c49e410b1c7050674bcfdabba1006fe375b32d5) [attempts](https://github.com/tarsius/llama/commit/580ad210e01cb54511aa399614e26feceeb17aaa) to fix this problem relied on the fact that `describe-function` calls `all-completions` down the call stack to filter this annoyance out, but helpful's `helpful--read-symbol` symbol uses the `obarray` directly without filtering. This PR addresses this issue by delegating to `help--symbol-completion-table` when it's available (Emacs >= 26.1).